### PR TITLE
modify plugins_url() call to use paramters

### DIFF
--- a/google-sitemap-plugin.php
+++ b/google-sitemap-plugin.php
@@ -157,7 +157,7 @@ if ( ! function_exists( 'gglstmp_sitemapcreate' ) ) {
 			$str .= "'" . $val . "'";
 		}
 		$xml = new DomDocument( '1.0', 'utf-8' );
-		$xml_stylesheet_path = plugins_url() . "/google-sitemap-plugin/sitemap.xsl";
+		$xml_stylesheet_path = plugins_url( 'sitemap.xsl', __FILE__ );
 
 		$xslt = $xml->createProcessingInstruction( 'xml-stylesheet', "type=\"text/xsl\" href=\"$xml_stylesheet_path\"" );
 		$xml->appendChild( $xslt );


### PR DESCRIPTION
Modify plugins_url() call to use parameters rather than
appending the rest of the path. This would allow a developer
to filter the call to plugins_url(), specifically to address the issue in
http://wordpress.org/support/topic/stylesheet-error-1?replies=5
By passing in these parameters, one could identify the correct
call to plugins_url() and filter it as necessary (in this case replacing
https:// with http://)
