### PR TITLE
Update google-sitemap-plugin.php

### DIFF
--- a/google-sitemap-plugin.php
+++ b/google-sitemap-plugin.php
@@ -45,7 +45,8 @@ if ( ! function_exists( 'gglstmp_init' ) ) {
 	function gglstmp_init() {
 		global $gglstmp_plugin_info;
 
-		if ( ! session_id() ) {
+		// Drop session cookie only if user is admin
+		if ( is_admin() && ! session_id() ) {
 			session_start();
 		}		
 

--- a/google-sitemap-plugin.php
+++ b/google-sitemap-plugin.php
@@ -46,7 +46,7 @@ if ( ! function_exists( 'gglstmp_init' ) ) {
 		global $gglstmp_plugin_info;
 
 		// Drop session cookie only if user is admin
-		if ( is_admin() && ! session_id() ) {
+		if ( !is_admin() && !defined('DOING_AJAX') && !session_id() ) {
 			session_start();
 		}		
 


### PR DESCRIPTION
For some of our client setups using Nginx for caching. 
If a 'PHPSESSID' cookie is created via the session_id() function for every page visitor, the page cannot be cached & under high traffic load, the server runs out of resources pretty quickly.

Because this function is hooked on init, the behavior to drop a session cookie has to be removed in order to hit cache for people that don't need dynamic content served.
